### PR TITLE
Add test with strict mode bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "microbundle build --tsconfig ./tsconfig.json --name VueBrowserAcl",
     "build:watch": "microbundle watch --tsconfig ./tsconfig.json --name VueBrowserAcl",
     "test": "jest --config jest.config.json",
-    "test:watch": "jest jest --config jest.config.json --watchAll",
+    "test:watch": "jest --config jest.config.json --watchAll",
     "version": "npm run build && git add -A ./dist",
     "postversion": "git push && git push --tags"
   },
@@ -37,19 +37,18 @@
     "browser-acl": "^0.9.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
-    "@nuxt/types": "^0.7.6",
-    "@types/jest": "^25.2.3",
-    "@vue/test-utils": "^1.0.3",
-    "babel-jest": "^26.0.1",
-    "jest": "^26.0.1",
-    "microbundle": "^0.12.0",
-    "ts-jest": "^26.0.0",
-    "typescript": "^3.9.3",
-    "vue": "^2.6.11",
-    "vue-router": "^3.2.0",
-    "vue-template-compiler": "^2.6.11"
+    "@babel/core": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@types/jest": "^26.0.20",
+    "@vue/test-utils": "^1.1.2",
+    "babel-jest": "^26.6.3",
+    "jest": "^26.6.3",
+    "microbundle": "^0.13.0",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.3",
+    "vue": "^2.6.12",
+    "vue-router": "^3.5.1",
+    "vue-template-compiler": "^2.6.12"
   },
   "prettier": {
     "semi": false,

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -83,17 +83,18 @@ const routes: RouteConfig[] = [
   }
 ]
 
-describe.only('Router integration', () => {
+describe('Router integration', () => {
   test('Strict mode', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
+
     const router = new VueRouter({ routes: routes })
     router.push("");
+
     localVue.use(VueAcl, getUser, (acl: Acl) => {
       acl.rule('idle', true)
     }, { router: router, failRoute: '/fallback', strict: true, assumeGlobal: true })
-
-
+    
     const wrapper = mount(
       {
         template: `


### PR DESCRIPTION
Hello @mblarsen,

I was testing strict mode and noticed that it doesn't appear to work correctly. 

As `metas` in the route guard filters out routes without `can`, you can end up with an empty `metas` array, then `chainCans` will simply resolve `true` via the reduce's `initialValue` and bypass the strict mode checks entirely.

The test in this PR currently fails, demonstrating the behavior. 