### PR TITLE
Fix Vue instance component type declaration.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import Acl from 'browser-acl'
 import { Verb, VerbObject, Options as AclOptions } from 'browser-acl'
-import { VueConstructor } from 'vue/types'
+import Vue, { VueConstructor } from 'vue/types'
 import VueRouter from 'vue-router/types'
 
 export { Verb, VerbObject, TestFunction } from 'browser-acl'
@@ -78,7 +78,7 @@ export type VueAcl = {
 }
 
 declare module 'vue/types/vue' {
-  interface VueConstructor {
+  interface Vue {
     $can: AclHelper
   }
 }


### PR DESCRIPTION
Previously, `vm.$can(...)` or (`this.$can(...)` if using class components), would fail typechecking because the compiler could not find `$can(...)`.

This updates the typing to follow the [official guidance] for extending the instance declaration.

I have validated this in my local project.

[official guidance]: https://vuejs.org/v2/guide/typescript.html#Augmenting-Types-for-Use-with-Plugins